### PR TITLE
stlouis milan_dxio_init fix invalid success return

### DIFF
--- a/usr/src/uts/oxide/milan/milan_fabric.c
+++ b/usr/src/uts/oxide/milan/milan_fabric.c
@@ -2994,7 +2994,7 @@ milan_dxio_init(zen_iodie_t *iodie, void *arg)
 	 */
 	if (!milan_dxio_rpc_set_var(iodie, MILAN_DXIO_VAR_PHY_PROG, 1) ||
 	    !milan_dxio_rpc_set_var(iodie, MILAN_DXIO_VAR_SKIP_PSP, 1)) {
-		return (0);
+		return (1);
 	}
 
 	return (0);


### PR DESCRIPTION
I think there might be a silenced error on the `milan_dxio_init` function, on the path initing `PHY_PROG` and `SKIP_PSP`.

This came out as I was reviewing the Milan path, and I don't have hardware to test on ! In any case if it's intended to ignore errors here, I think a comment would be good. 
 
You don't seem to be taking PRs here, but I just wanted to surface this. Cheers !